### PR TITLE
Look for the `data-noprefix` attribute on injected style elements

### DIFF
--- a/prefixfree.js
+++ b/prefixfree.js
@@ -84,6 +84,9 @@ var self = window.StyleFix = {
 	},
 
 	styleElement: function(style) {
+		if (style.hasAttribute('data-noprefix')) {
+			return;
+		}
 		var disabled = style.disabled;
 		
 		style.textContent = self.fix(style.textContent, true, style);


### PR DESCRIPTION
There is already similar behavior on the link() function, but this allows a script to specify that they do not want prefixfree to run against the injected css.

This came up because for some reason prefixfree conflicts with a datagrid plugin we are using that injects its styles into the DOM when it runs.
