### PR TITLE
add `component` compability

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,15 @@ Prefixes the properties and values in the code passed with the prefix of the cur
 	PrefixFree.prefixSelector(selector)
 	PrefixFree.prefixProperty(property)
 Prefixes the passed selector or property **even when it's supported prefix-less**. These are more internal methods and I assume they won't be too useful in general.
+
+## Using via [Component](https://github.com/component/component)
+
+[Component](https://github.com/component/component) is an excellent package manager. You can use prefixfree via component by add adding this into your `component.json`
+		
+	  "dependencies": {
+	    "LeaVerou/prefixfree@gh-pages": "*"
+	  }
+
+Then activate prefixfree by:
+		
+		require('LeaVerou/prefixfree/prefixfree.js')(document.documentElement);

--- a/component.json
+++ b/component.json
@@ -1,0 +1,13 @@
+{
+  "name": "prefixfree",
+  "repo": "LeaVerou/prefixfree",
+  "description": "Break free from CSS prefix hell!",
+  "version": "1.0.7",
+  "keywords": [],
+  "dependencies": {},
+  "development": {},
+  "license": "MIT",
+  "scripts": [
+    "prefixfree.js"
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -76,6 +76,10 @@
 	<h1>How to use</h1>
 	<p>Just include <code>prefixfree.js</code> anywhere in your page. It is recommended to put it right after the stylesheets, to minimize <abbr title="Flash Of UnCSS3-ed Content">FOUC</abbr>
 	<p>That’s it, you’re done!</p>
+	<p>You can also use <code>prefixfree.js</code> via 
+		<a href="https://github.com/component/component">component</a>. 
+		<a href="#faq">learn more</a>
+	</p>
 </section>
 </div>
 
@@ -123,8 +127,23 @@
 
 
 <section id="faq" class="page">
+
 	<h1>FAQ</h1>
-	
+	<section>
+	<h1>Can I use it via
+		<a href="https://github.com/component/component">Component</a>?
+	</h1>
+	<p>
+		Sure thing. You can use prefixfree via component by add adding this into your
+		<code>component.json</code>
+	</p>
+	<pre>
+"dependencies": { "LeaVerou/prefixfree@gh-pages": "*" } </pre>
+	<p>Then activate prefixfree by:</p>
+	<pre>
+require('LeaVerou/prefixfree/prefixfree.js')(document.documentElement); 
+	</pre>
+	</section>
 	<section>
 		<h1>What if I actually want to target only a specific prefix?</h1>
 		<p>Properties/values etc that <strong>already</strong> have a prefix won’t be altered. However, if you use the unprefixed property/value etc after the prefixed properties, you might run into <a href="https://github.com/LeaVerou/prefixfree/issues/16#issuecomment-2428237" target="_blank">issue #16</a>.

--- a/prefixfree.js
+++ b/prefixfree.js
@@ -153,17 +153,6 @@ var self = window.StyleFix = {
 	}
 };
 
-/**************************************
- * Process styles
- **************************************/
-(function(){
-	setTimeout(function(){
-		$('link[rel="stylesheet"]').forEach(StyleFix.link);
-	}, 10);
-	
-	document.addEventListener('DOMContentLoaded', StyleFix.process, false);
-})();
-
 function $(expr, con) {
 	return [].slice.call((con || document).querySelectorAll(expr));
 }
@@ -173,7 +162,13 @@ function $(expr, con) {
 /**
  * PrefixFree
  */
-(function(root){
+(function(prefixFree){
+	if(typeof(module)=='undefined'){
+		prefixFree(document.documentElement);
+	}else{
+		module.exports = prefixFree;
+	}
+})(function(root){
 
 if(!window.StyleFix || !window.getComputedStyle) {
 	return;
@@ -483,5 +478,18 @@ root.className += ' ' + self.prefix;
 
 StyleFix.register(self.prefixCSS);
 
+/**************************************
+ * Process styles
+ **************************************/
 
-})(document.documentElement);
+setTimeout(function(){
+	$('link[rel="stylesheet"]').forEach(StyleFix.link);
+}, 10);
+
+function $(expr, con) {
+	return [].slice.call((con || document).querySelectorAll(expr));
+}
+
+document.addEventListener('DOMContentLoaded', StyleFix.process, false);
+
+});


### PR DESCRIPTION
I use prefixfree a lot in my projects, and I find it would be easier to add it to one project via a package manager. So I added component.json for [component](https://github.com/component/component) and a few tricks to make it CommonJS compatible.
