### PR TITLE
Remove hash-bang from link to Eric Meyer's tweet so it works again

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,9 +39,9 @@
 	</ul>
 </nav>
 
-<blockquote cite="http://twitter.com/#!/meyerweb/status/124618575263711232">
+<blockquote cite="http://twitter.com/meyerweb/status/124618575263711232">
 	<p>“[-prefix-free is] fantastic, top-notch work! Thank you for creating and sharing it.”</p>
-	— <a href="http://twitter.com/#!/meyerweb/status/124618575263711232" target="_blank">Eric Meyer</a>
+	— <a href="http://twitter.com/meyerweb/status/124618575263711232" target="_blank">Eric Meyer</a>
 </blockquote>
 
 <div class="section-container">


### PR DESCRIPTION
(Just took you to twitter.com instead of the tweet)
