### PR TITLE
Fix a bug in PrefixFree.property and finish implementing PrefixFree.value

### DIFF
--- a/prefixfree.js
+++ b/prefixfree.js
@@ -232,7 +232,7 @@ var self = window.PrefixFree = {
 	},
 	
 	property: function(property) {
-		return (self.properties.indexOf(property)? self.prefix : '') + property;
+		return (self.properties.indexOf(property) >=0 ? self.prefix : '') + property;
 	},
 	
 	value: function(value, property) {

--- a/prefixfree.js
+++ b/prefixfree.js
@@ -238,9 +238,11 @@ var self = window.PrefixFree = {
 	value: function(value, property) {
 		value = fix('functions', '(^|\\s|,)', '\\s*\\(', '$1' + self.prefix + '$2(', value);
 		value = fix('keywords', '(^|\\s)', '(\\s|$)', '$1' + self.prefix + '$2$3', value);
-		
-		// TODO properties inside values
-		
+
+		if(self.valueProperties.indexOf(property) >= 0) {
+			value = fix('properties', '(^|\\s|,)', '($|\\s|,)', '$1'+self.prefix+'$2$3', value);
+		}
+
 		return value;
 	},
 	


### PR DESCRIPTION
I'm using PrefixFree.property to set styles from Javascript, it prefixes all properties before this fix. Also using PrefixFree.value. Aim is for the Javascript devs I'm working with to stop having to be concerned with prefixes :)
Commits are self explanatory I think.
PrefixFree rocks :) 
Thanks to Lea and all contributors
