### PR TITLE
Update prefixfree.viewport-units.js

### DIFF
--- a/plugins/prefixfree.viewport-units.js
+++ b/plugins/prefixfree.viewport-units.js
@@ -25,7 +25,7 @@ if(!units.length) {
 StyleFix.register(function(css) {
 	var w = innerWidth, h = innerHeight;
 	
-	return css.replace(RegExp('\\b(\\d+\\.?\\d*)(' + units.join('|') + ')\\b', 'gi'), function($0, num, unit) {
+	return css.replace(RegExp('\\b(\\d*\\.?\\d+)(' + units.join('|') + ')\\b', 'gi'), function($0, num, unit) {
 		switch (unit) {
 			case 'vw':
 				return num * w / 100 + 'px';


### PR DESCRIPTION
- `2.` is not allowed as number
- `.2` is allowed
