### PR TITLE
Viewport units plugin is now responsive

### DIFF
--- a/index.html
+++ b/index.html
@@ -208,17 +208,14 @@
 		<p>A static polyfill for the new <a href="http://www.w3.org/TR/css3-values/#viewport-relative-lengths">vw, vh, vmin, vmax units</a>.</p>
 		<ul class="features">
 			<li>Will do nothing if the units are supported natively.</li>
-		</ul>
-		Limitations:
-		<ul class="drawbacks">
-			<li>It’s not dynamic. The lengths are replaced once, and then they function as normal CSS pixel values. So, they won’t update when the window is resized, but only on load.</li>
+			<li>It’s dynamic. Pixel values are updated on screen resize.</li>
 		</ul>
 		<ul>
 			<li><a href="https://raw.github.com/LeaVerou/prefixfree/gh-pages/plugins/prefixfree.viewport-units.js">prefixfree.viewport-units.js</a></li>
 		</ul>
 	</section>
 	
-	<section id="viewport-units">
+	<section id="css-variables">
 		<h1>CSS Variables</h1>
 		<p>Enables rudimentary <a href="http://www.w3.org/TR/css-variables/">CSS variables</a> support.</p>
 		<ul class="features">

--- a/plugins/prefixfree.viewport-units.js
+++ b/plugins/prefixfree.viewport-units.js
@@ -24,19 +24,36 @@ if(!units.length) {
 
 StyleFix.register(function(css) {
 	var w = innerWidth, h = innerHeight;
-	
-	return css.replace(RegExp('\\b(\\d+\\.?\\d*)(' + units.join('|') + ')\\b', 'gi'), function($0, num, unit) {
+	// For help with this monster regex: see debuggex.com: https://www.debuggex.com/r/cpzpAHiWPagP3Zru
+	return css.replace(RegExp('(-?[a-z]+(?:-[a-z]+)*\\s*:\\s*)\\b([0-9]*\\.?[0-9]+)(' + units.join('|') + ')\\b(?:\\s*;\\s*\\1\\b(?:[0-9]*\\.?[0-9]+)(?:px)\\b)?;?', 'gi'), function($0, property, num, unit) {
+		if (!unit) return $0;
+		var value;
 		switch (unit) {
 			case 'vw':
-				return num * w / 100 + 'px';
+				value = num * w / 100 + 'px';
+				break;
 			case 'vh':
-				return num * h / 100 + 'px';
+				value = num * h / 100 + 'px';
+				break;
 			case 'vmin':
-				return num * Math.min(w,h) / 100 + 'px';
+				value = num * Math.min(w,h) / 100 + 'px';
+				break;
 			case 'vmax':
-				return num * Math.max(w,h) / 100 + 'px';
+				value = num * Math.max(w,h) / 100 + 'px';
+				break;
 		}
+		return property + num + unit + ';' + property + value + ';';
 	});
 });
+
+var styleFixResizeTimer;
+
+window.addEventListener('resize', function () {
+	// 100ms interruptable delay because the computation is expensive
+	if (typeof styleFixResizeTimer !== 'undefined') clearTimeout(styleFixResizeTimer);
+	styleFixResizeTimer = setTimeout(function () {
+		StyleFix.process();
+	}, 100);
+}, false);
 
 })();

--- a/plugins/prefixfree.viewport-units.js
+++ b/plugins/prefixfree.viewport-units.js
@@ -48,12 +48,15 @@ StyleFix.register(function(css) {
 
 var styleFixResizeTimer;
 
-window.addEventListener('resize', function () {
+var resizeListener = function () {
 	// 100ms interruptable delay because the computation is expensive
 	if (typeof styleFixResizeTimer !== 'undefined') clearTimeout(styleFixResizeTimer);
 	styleFixResizeTimer = setTimeout(function () {
 		StyleFix.process();
 	}, 100);
-}, false);
+};
+
+window.addEventListener('resize', resizeListener, false);
+window.addEventListener('orientationchange', resizeListener, false);
 
 })();


### PR DESCRIPTION
The function now appends the `px` version of the declaration after the viewport unit declaration, instead of replacing it. The regex now matches not only the viewport declaration, but also the
subsequent pixel replacement, e.g.:

``` css
height: 15vw;
```

matches, and:

``` css
height: 15vw; height: 150px;
```

also matches, and might be rewritten to:

``` css
height: 15vw; height: 100px;
```

on screen width resize.

Please note, I've been careful to only match a direct repetition of the same property, e.g.:

``` css
height: 15vw; width: 100px;
```

will only match on `height: 15vw;`, it won't overwrite the `width` declaration.

The event listener has a 100ms interruptible delay so that the function only runs if it hasn't been fired for at least 100ms. It's a computationally expensive function to run, and the resize event can continuously fire during a screen resize.

I tested this in Firefox Developer Edition and Chrome Unstable by simply force running the function whether or not there was support for viewport relative units. The inspection tools in both browsers reported pixel values for any elements I'd used viewport relative units for, and they resized when the browser window size changed.

Fixes https://github.com/LeaVerou/prefixfree/issues/194.
