### PR TITLE
HTTPS all of the things

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,9 +39,9 @@
 	</ul>
 </nav>
 
-<blockquote cite="http://twitter.com/meyerweb/status/124618575263711232">
+<blockquote cite="https://twitter.com/meyerweb/status/124618575263711232">
 	<p>“[-prefix-free is] fantastic, top-notch work! Thank you for creating and sharing it.”</p>
-	— <a href="http://twitter.com/meyerweb/status/124618575263711232" target="_blank">Eric Meyer</a>
+	— <a href="https://twitter.com/meyerweb/status/124618575263711232" target="_blank">Eric Meyer</a>
 </blockquote>
 
 <div class="section-container">
@@ -237,18 +237,18 @@
 </section>
 
 <footer>
-	<a href="http://twitter.com/prefixfree" target="_blank">@prefixfree</a>
+	<a href="https://twitter.com/prefixfree" target="_blank">@prefixfree</a>
 	✿ <a href="https://github.com/LeaVerou/prefixfree/commits/gh-pages.atom" target="_blank">Commits feed</a>
 	✿ Made by <a href="http://lea.verou.me/">Lea Verou</a> with care
 </footer>
 
 <script src="index.js"></script>
 
-<a href="http://twitter.com/share" class="twitter-share-button" data-count="vertical" data-via="prefixfree" data-related="LeaVerou">Tweet</a>
-<script src="http://platform.twitter.com/widgets.js"></script>
+<a href="https://twitter.com/share" class="twitter-share-button" data-count="vertical" data-via="prefixfree" data-related="LeaVerou">Tweet</a>
+<script src="https://platform.twitter.com/widgets.js"></script>
 
 <script>var _gaq = [['_setAccount', 'UA-25106441-4'],['_trackPageview']];</script>
-<script src="http://www.google-analytics.com/ga.js" async></script>
+<script src="https://www.google-analytics.com/ga.js" async></script>
 
 </body>
 </html>


### PR DESCRIPTION
Updated relevant links to HTTPS. Twitter serves everything over HTTPS anyway so it saves a HTTP redirect. 
