### PR TITLE
Add 'will-change' to the 'valueProperties' list.

### DIFF
--- a/prefixfree.js
+++ b/prefixfree.js
@@ -493,7 +493,8 @@ root.removeChild(style);
 // Properties that accept properties as their value
 self.valueProperties = [
 	'transition',
-	'transition-property'
+	'transition-property',
+	'will-change'
 ]
 
 // Add class for current prefix


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/CSS/will-change

For the sake of completeness. It is probably not very relevant, at least for the main use case: `transform`, and `opacity`, which are unprefixed in browsers that support `will-change`. That property is also a pure performance optimization.

Aside, if this was accepted, do you want me to regenerate the minified version?
