### PR TITLE
Updating bower.json with homepage and tags

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,10 +1,13 @@
 {
   "name": "prefixfree",
-  "version": "1.0.9",
   "main": "prefixfree.js",
-   "author": {
-    "name": "Lea Verou"
-  },
+  "version": "1.0.10",
+  "homepage": "http://leaverou.github.io/prefixfree/",
+  "authors": [
+    "Lea Verou"
+  ],
+  "description": "A script that lets you use only unprefixed CSS properties everywhere. It works behind the scenes, adding the current browser’s prefix to any CSS code, only when it’s needed.",
+  "license": "MIT",
   "ignore": [
     "css/",
     "fonts/",
@@ -15,7 +18,6 @@
     "minify",
     "**/*.min.js"
   ],
-  "description": "A script that lets you use only unprefixed CSS properties everywhere. It works behind the scenes, adding the current browser’s prefix to any CSS code, only when it’s needed.",
   "repository": {
     "type": "git",
     "url": "git://github.com/LeaVerou/prefixfree.git#gh-pages"


### PR DESCRIPTION
Tagging the gh-pages branch will give us a way to install prefixfree using just `bower i prefixfree`.
To tag a release:
### tag the commit

git tag -a v1.0.10 -m "Release version 1.0.10"
### push to GitHub

git push origin gh-pages --tags  

Or use the Github GUI, like so:
1. Click releases
2. Create a new release
3. Same as above, version number is important.

Fixes #6116 #173 
