### PR TITLE
Update for modern syntax

### DIFF
--- a/plugins/prefixfree.vars.js
+++ b/plugins/prefixfree.vars.js
@@ -12,24 +12,9 @@ if(!window.StyleFix || !window.PrefixFree) {
 // Feature test
 var prefix = PrefixFree.prefix, dummy = document.createElement('_').style;
 
-dummy.cssText = 'var-foo: red; background: var(foo);';
+dummy.cssText = '--foo: red; background: var(--foo);';
 
 if (dummy.background) { // Unprefixed support
-	return;
-}
-
-dummy.cssText = prefix + 'var-foo: red; background: ' + prefix + 'var(foo);';
-
-if (dummy.background) { // Prefixed support
-
-	StyleFix.register(function(css) {
-		// var- properties
-		css = css.replace(/(^|\{|\s|;)var-([\w-]+)\s*:/gi, '$1' + prefix + 'var-$2:');
-		
-		// var() function
-		return css.replace(/(\s|:|,)var\s*\(/gi, '$1' + prefix + 'var(');
-	});
-	
 	return;
 }
 
@@ -40,15 +25,16 @@ var vars = {};
 
 StyleFix.register(function(css) {
 	// We need to handle get and set at the same time, to allow overwriting of the same variable later on
-	return css.replace(/(?:^|\{|\s|;)var-(?:[\w-]+)\s*:\s*[^;}]+|(\s|:|,)var\s*\(([\w-]+)\)/gi, function($0, before, id) {
-		var declaration = $0.match(/(^|\{|\s|;)var-([\w-]+)\s*:\s*([^;}]+)/i);
+	return css.replace(/(?:^|\{|\s|;)--(?:[\w-]+)\s*:\s*[^;}]+|(\s|:|,)var\s*\(\s*--([\w-]+)(?:\s*|,\s*)?([\w-]+)?\)/gi, function($0, before, id, fallback) {
+		var declaration = $0.match(/(^|\{|\s|;)--([\w-]+)\s*:\s*([^;}]+)/i);
 		
 		if (declaration) {
 			vars[declaration[2]] = declaration[3];
 		}
 		else {
 			// Usage
-			return before + (vars[id] || 'initial');
+			fallback = fallback ? fallback.replace('--','') : null;
+			return before + (vars[id] || vars[fallback] || fallback || 'initial');
 		}
 	});
 });


### PR DESCRIPTION
Change from 'var-foo: red' to '--foo: red'
Remove attempt to prefix, because no browsers supported a prefixed version (according to CanIUse).
Update regex to use '--' instead of 'var', and handle more whitespace and a fallback value.