### PR TITLE
Add a way to limit which stylesheets are processed

### DIFF
--- a/prefixfree.js
+++ b/prefixfree.js
@@ -11,11 +11,14 @@ if(!window.addEventListener) {
 }
 
 var self = window.StyleFix = {
+	limit: document.currentScript.hasAttribute("data-prefix"),
+
 	link: function(link) {
 		var url = link.href || link.getAttribute('data-href');
 		try {
 			// Ignore stylesheets with data-noprefix attribute as well as alternate stylesheets or without (data-)href attribute
-			if(!url || link.rel !== 'stylesheet' || link.hasAttribute('data-noprefix')) {
+			if(!url || link.rel !== 'stylesheet' || link.hasAttribute('data-noprefix')
+				|| (self.limit && !link.hasAttribute('data-prefix')) ) {
 				return;
 			}
 		}

--- a/prefixfree.js
+++ b/prefixfree.js
@@ -11,14 +11,14 @@ if(!window.addEventListener) {
 }
 
 var self = window.StyleFix = {
-	limit: document.currentScript.hasAttribute("data-prefix"),
+	optIn: document.currentScript.hasAttribute("data-prefix"),
 
 	link: function(link) {
 		var url = link.href || link.getAttribute('data-href');
 		try {
 			// Ignore stylesheets with data-noprefix attribute as well as alternate stylesheets or without (data-)href attribute
 			if(!url || link.rel !== 'stylesheet' || link.hasAttribute('data-noprefix')
-				|| (self.limit && !link.hasAttribute('data-prefix')) ) {
+				|| (self.optIn && !link.hasAttribute('data-prefix')) ) {
 				return;
 			}
 		}


### PR DESCRIPTION
Implements #6137.
Adds limit property which is boolean and reflects the existence of a data-prefix attribute on the script tag.
If it is there, it affects the <link> styles. Only those with a data-prefix attribute are processed.