### PR TITLE
Fix URL to prevent a redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# [-prefix-**free**](https://leaverou.github.com/prefixfree/)
+# [-prefix-**free**](https://leaverou.github.io/prefixfree/)
 ## Break free from CSS prefix hell!
 
-[Project homepage](https://leaverou.github.com/prefixfree/)
+[Project homepage](https://leaverou.github.io/prefixfree/)
 
 A script that lets you use only unprefixed CSS properties everywhere. 
 It works behind the scenes, adding the current browser’s prefix to any CSS code, only when it’s needed.


### PR DESCRIPTION
Hi Lea. Realised that:
leaverou.github.com/prefixfree/
redirects to:
leaverou.github.io/prefixfree/
- so I updated the URL in the README