### PR TITLE
add missing :placeholder-shown selector

### DIFF
--- a/prefixfree.js
+++ b/prefixfree.js
@@ -467,9 +467,9 @@ selectors = {
 	':full-screen': ':fullscreen',
 	//sigh
 	'::placeholder': null,
-	':placeholder': '::placeholder',
+	':placeholder': ':placeholder-shown',
 	'::input-placeholder': '::placeholder',
-	':input-placeholder': '::placeholder',
+	':input-placeholder': ':placeholder-shown',
 	':read-only': null,
 	':read-write': null,
 	'::selection': null


### PR DESCRIPTION
The selector to use for the psuedo-class `:placeholder-shown` was incorrectly attributed to `::placeholder`.
Both have two possible names for the vendor prefixes, but the number of colons do not change (psuedo-class vs. psuedo-element).

For #6143