### PR TITLE
add handling for :matches and :is

### DIFF
--- a/prefixfree.js
+++ b/prefixfree.js
@@ -461,7 +461,7 @@ for (var keyword in keywords) {
 
 var
 selectors = {
-	':any': ':matches',
+	':any': ':is',
 	':any-link': null,
 	'::backdrop': null,
 	':fullscreen': null,
@@ -498,7 +498,8 @@ var prefixed;
 for(var selector in selectors) {
 	var standard = selectors[selector] || selector
 	prefixed = selector.replace(/::?/, function($0) { return $0 + self.prefix });
-	if(!supported(standard) && (supported(prefixed) || supported(prefixed + '(a,p)') )) {
+	if((!supported(standard) && !supported(standard + '(a,p)')) && 
+	   (supported(prefixed) || supported(prefixed + '(a,p)') )) {
 		self.selectors.push(standard);
 		self.selectorMap[standard] = prefixed;
 	}

--- a/prefixfree.js
+++ b/prefixfree.js
@@ -461,6 +461,8 @@ for (var keyword in keywords) {
 
 var
 selectors = {
+	':any': ':matches',
+	':is': null,
 	':any-link': null,
 	'::backdrop': null,
 	':fullscreen': null,
@@ -493,10 +495,12 @@ function supported(selector) {
 	return !!style.sheet.cssRules.length;
 }
 
+var prefixed;
 for(var selector in selectors) {
 	var standard = selectors[selector] || selector
-	var prefixed = selector.replace(/::?/, function($0) { return $0 + self.prefix })
-	if(!supported(standard) && supported(prefixed)) {
+	prefixed = (standard === ':is') ? (':' + self.prefix + 'any') :
+		selector.replace(/::?/, function($0) { return $0 + self.prefix });
+	if(!supported(standard) && (supported(prefixed) || supported(prefixed + '(a,p)') )) {
 		self.selectors.push(standard);
 		self.selectorMap[standard] = prefixed;
 	}

--- a/prefixfree.js
+++ b/prefixfree.js
@@ -462,7 +462,6 @@ for (var keyword in keywords) {
 var
 selectors = {
 	':any': ':matches',
-	':is': null,
 	':any-link': null,
 	'::backdrop': null,
 	':fullscreen': null,
@@ -498,8 +497,7 @@ function supported(selector) {
 var prefixed;
 for(var selector in selectors) {
 	var standard = selectors[selector] || selector
-	prefixed = (standard === ':is') ? (':' + self.prefix + 'any') :
-		selector.replace(/::?/, function($0) { return $0 + self.prefix });
+	prefixed = selector.replace(/::?/, function($0) { return $0 + self.prefix });
 	if(!supported(standard) && (supported(prefixed) || supported(prefixed + '(a,p)') )) {
 		self.selectors.push(standard);
 		self.selectorMap[standard] = prefixed;


### PR DESCRIPTION
`:any` and `:matches` and `:is` need selector lists to test support, so the additional call was added.
`:is` is a special case since the standard renamed it, so it gets its own if statement.

For part of #6130