### PR TITLE
add sticky and stretch keywords

### DIFF
--- a/prefixfree.js
+++ b/prefixfree.js
@@ -415,6 +415,8 @@ var keywords = {
 	'min-content': 'width',
 	'fit-content': 'width',
 	'fill-available': 'width',
+	'stretch': 'width',
+	'sticky': 'position',
 	'contain-floats': 'width'
 };
 


### PR DESCRIPTION
The stretch keyword is not mentioned in the working draft of the spec, but it is supported with a prefix by some browsers. Unfortunately, I couldn't see a good way to do a special case with it for `-moz-available`.

For part of #6130 